### PR TITLE
Add more names for 5120x2880 resolution

### DIFF
--- a/FluffyDisplay/AppDelegate.swift
+++ b/FluffyDisplay/AppDelegate.swift
@@ -39,7 +39,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NetServiceDelegate, NetServi
       // https://www.theverge.com/tldr/2016/3/21/11278192/apple-iphone-ipad-screen-sizes-pixels-density-so-many-choices
 
       Resolution(6016, 3384, 218, true,  "Apple Pro Display XDR"),
-      Resolution(5120, 2880, 218, true,  "27-inch iMac with Retina 5K display"),
+      Resolution(5120, 2880, 218, true,  "UHD+, 27-inch Apple Studio Display, 27-inch iMac with Retina 5K display"),
       Resolution(4096, 2304, 219, true,  "21.5-inch iMac with Retina 4K display"),
       Resolution(3840, 2400, 200, true,  "WQUXGA"),
       Resolution(3840, 2160, 200, true,  "UHD"),


### PR DESCRIPTION
The 5120x2880 resolution used by the 5K iMac is also used by the new Apple Studio Display so I added that to the description of that resolution. I also added "UHD+" although according to Wikipedia that's not standardized, and Dell sometimes uses "UDH+" to mean "WQUXGA", so another option would be to refer to this resolution just as "5K".