### PR TITLE
Add a name for 1920x1200 resolution and change PPI

### DIFF
--- a/FluffyDisplay/AppDelegate.swift
+++ b/FluffyDisplay/AppDelegate.swift
@@ -52,7 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NetServiceDelegate, NetServi
       Resolution(2304, 1440, 226, true,  "12-inch MacBook with Retina display"),
       Resolution(2048, 1536, 150, false, "QXGA"),
       Resolution(2048, 1152, 150, false, "QWXGA"),
-      Resolution(1920, 1200, 150, false, "WUXGA"),
+      Resolution(1920, 1200, 98,  false, "WUXGA, 23-inch Apple Cinema HD Display"),
       Resolution(1600, 1200, 125, false, "UXGA"),
       Resolution(1920, 1080, 102, false, "HD, 21.5-inch iMac"),
       Resolution(1680, 1050, 99,  false, "WSXGA+, Apple Cinema Display (20-inch), 20-inch iMac"),


### PR DESCRIPTION
I wasn't sure if you prefer for resolutions to have names of products that use that resolution. If so, this updates the description of 1920x1200 resolution to mention the 23-inch Apple Cinema HD Display.

It also  changes the PPI from 150 to 98 (the PPI of the Cinema HD Display). I'm not sure the significance of the PPI for FluffyDisplay or if this change is undesirable for some reason, but presumably 150 was just an estimate since previously this setting did not refer to a specific display and now it does.