### PR TITLE
Fix some functional issue

### DIFF
--- a/FluffyDisplay/AppDelegate.swift
+++ b/FluffyDisplay/AppDelegate.swift
@@ -225,6 +225,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NetServiceDelegate, NetServi
             menuItem.menu?.removeItem(menuItem)
             // We can clear our TXT record now
             ns.setTXTRecord(nil)
+            
+            if deleteMenu.numberOfItems == 0 {
+                deleteSubmenu.isHidden = true
+            }
         }
     }
 


### PR DESCRIPTION
When there has no virtual display at all after the first connection, we
should hide the added delete menue.